### PR TITLE
added a null check to avoid issues with rooms having geometry having faces that won't triangulate

### DIFF
--- a/TrackChanges/Command.cs
+++ b/TrackChanges/Command.cs
@@ -300,17 +300,19 @@ public class Command : IExternalCommand
     {
       Mesh m = f.Triangulate();
 
-      foreach( XYZ p in m.Vertices )
+      if (m != null)
       {
-        XYZ q = t.OfPoint( p );
-
-        if( !vertexLookup.ContainsKey( q ) )
+        foreach( XYZ p in m.Vertices )
         {
-          vertexLookup.Add( q, 1 );
-        }
-        else
-        {
-          ++vertexLookup[q];
+          XYZ q = t.OfPoint( p );
+          if( !vertexLookup.ContainsKey( q ) )
+          {
+            vertexLookup.Add( q, 1 );
+          }
+          else
+          {
+            ++vertexLookup[q];
+	      }
         }
       }
     }


### PR DESCRIPTION
I ran the original code against the Revit 2016 out-of-the-box model named rme_advanced_sample_project.rvt, and it failed due to a room that had geometry which somehow prevented the mesh from being generated when f.Triangluate() was called on a face.  After I made this change, the code executed successfully.
